### PR TITLE
Add Timezone support for php CLI

### DIFF
--- a/glpi-start.sh
+++ b/glpi-start.sh
@@ -5,7 +5,9 @@
 	&& VERSION_GLPI=$(curl -s https://api.github.com/repos/glpi-project/glpi/releases/latest | grep tag_name | cut -d '"' -f 4)
 
 if [[ -z "${TIMEZONE}" ]]; then echo "TIMEZONE is unset"; 
-else echo "date.timezone = \"$TIMEZONE\"" > /etc/php/7.3/apache2/conf.d/timezone.ini;
+else 
+echo "date.timezone = \"$TIMEZONE\"" > /etc/php/7.3/apache2/conf.d/timezone.ini;
+echo "date.timezone = \"$TIMEZONE\"" > /etc/php/7.3/cli/conf.d/timezone.ini;
 fi
 
 SRC_GLPI=$(curl -s https://api.github.com/repos/glpi-project/glpi/releases/tags/${VERSION_GLPI} | jq .assets[0].browser_download_url | tr -d \")


### PR DESCRIPTION
When using mail collector, GLPI uses php-cli which is not configured with TIMEZONE. 
Follow tickets by mail is incomprehensible because tickets are opening on UTC. 
This merge adds TIMEZONE support and fixes this problem.