### PR TITLE
Fixing commit b9510bcaa5da65288e53acfc1738bc48eae6562e as t…

### DIFF
--- a/glpi-start.sh
+++ b/glpi-start.sh
@@ -22,9 +22,9 @@ then
     echo -e "TLS_REQCERT\tnever" >> /etc/ldap/ldap.conf
 fi
 
-# Check if GLPI, but not only the plugins folder is present. This way it is possible to install plugins
-# before GLPI is started which makes it easier to build custom Docker images based on diouxx/glpi.
-if [ -d "${FOLDER_WEB}${FOLDER_GLPI}" ] && [ "$(ls ${FOLDER_WEB}${FOLDER_GLPI})" != "plugins" ];
+# Check if GLPI + the index.php are installed. This way it is possible to install plugins before
+# GLPI is started which makes it easier to build custom Docker images based on diouxx/glpi.
+if [ -d "${FOLDER_WEB}${FOLDER_GLPI}" ] && [ -f "${FOLDER_WEB}${FOLDER_GLPI}index.php" ];
 then
 	echo "GLPI is already installed"
 else


### PR DESCRIPTION
…he GLPI installation doesn't work properly anymore.

The installation worked properly with the example docker-compose.yml where no volumes were mapped, but didn't work, when the volume mapping /var/www/html/glpi/:/var/www/html/glpi was included. Docker created the volume folder, the container was started, checked if the glpi directory was present (which it was) and did the additional check, if 'ls /var/www/html/glpi' didn't just return 'plugins'. This check might failed since the glpi directory existed, but 'ls /var/www/html/glpi' returned an empty string and thus considered GLPI to be installed.