### PR TITLE
added redis package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ php-cas \
 php7.4-intl \
 php7.4-zip \
 php7.4-bz2 \
+php7.4-redis \
 cron \
 wget \
 ca-certificates \


### PR DESCRIPTION
GLPI can use a redis server as cache, but `php7.4-redis` needs to be installed in the container