### PR TITLE
Update glpi-start.sh

### DIFF
--- a/glpi-start.sh
+++ b/glpi-start.sh
@@ -55,7 +55,7 @@ else
 fi
 
 #Add scheduled task by cron and enable
-echo "*/2 * * * * www-data /usr/bin/php /var/www/html/glpi/front/cron.php &>/dev/null" >> /etc/cron.d/glpi
+echo "*/2 * * * * www-data /usr/bin/php /var/www/html/glpi/front/cron.php &>/dev/null" > /etc/cron.d/glpi
 #Start cron service
 service cron start
 


### PR DESCRIPTION
When the container starts, this command append the line every time. After 13 months of daily container restarts (because of bareos backup), whe have /etc/cron.d/glpi with more than 500+ line of similar crons. This make a critical CPU utilize on server. 
When the .sh was changed, as i propose, CPU utilize make normal and /etc/cron.d/glpi contains olny 1 line after every startup. Glpi also works fine.
