### PR TITLE
Fix to kill apache before start it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 docker-compose-test.yml
+cust-entry.sh
+data
+start-docker.sh

--- a/glpi-start.sh
+++ b/glpi-start.sh
@@ -62,5 +62,8 @@ service cron start
 #Activation du module rewrite d'apache
 a2enmod rewrite && service apache2 restart && service apache2 stop
 
+#Fix to really stop apache
+pkill -9 apache
+
 #Lancement du service apache au premier plan
 /usr/sbin/apache2ctl -D FOREGROUND


### PR DESCRIPTION
It's necessary because 'service apache2 stop' leaves some process alive