### PR TITLE
Fix: Installation does not happen when glpi volume is provided by a persistent volume on kubernetes

### DIFF
--- a/glpi-start.sh
+++ b/glpi-start.sh
@@ -24,7 +24,7 @@ then
 fi
 
 #Téléchargement et extraction des sources de GLPI
-if [ "$(ls ${FOLDER_WEB}${FOLDER_GLPI})" ];
+if [ "$(ls ${FOLDER_WEB}${FOLDER_GLPI}/bin)" ];
 then
 	echo "GLPI is already installed"
 else


### PR DESCRIPTION
# Fix: Installation does not happen when glpi volume is provided by a persistent volume on kubernetes
When used in a kubernetes context with a persistent volume storing data for glpi folder, the installer will not run as it tests for the glpi directory and that directory has been provided by Kubernetes storage class.

I suggest the bin directory is tested instead of the root of the glpi directory. This way, if a persistent volume has been provided, but glpi has not yet been installed, the installation will still happen. Once it's been completed, the bin directory will exist and installation will not happen.

This will also ensure that new installation is performed when the container is upgrade to a new version as the new container will not contain the bin directory, only the files, plugins, config, and marketplace which are provided as volumes.

Example deployment.yaml file below:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: glpi
  labels:
    app: glpi
    tier: front
  namespace: glpi
spec:
  selector:
    matchLabels:
      app: glpi
      tier: front
  strategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: glpi
        tier: front
    spec:
      containers:
        - name: glpi
          image: oboudry/docker-glpi:latest # build of modified diouxx/docker-glpi dockerfile
          env:
            - name: TZ
              value: "Europe/Paris"
          ports:
            - containerPort: 80
          volumeMounts:
            - name: glpi-config
              mountPath: /var/www/html/glpi/config
            - name: glpi-marketplace
              mountPath: /var/www/html/glpi/marketplace
            - name: glpi-plugins
              mountPath: /var/www/html/glpi/plugins
            - name: glpi-files
              mountPath: /var/www/html/glpi/files
            - name: crontab-volume
              mountPath: /etc/cron.d/glpi
              subPath: glpi
          lifecycle:
            preStop:
              exec:
                command: ["sleep", "60"]
          resources:
            requests:
              memory: "256Mi"
              cpu: "50m"
            limits:
              memory: "1Gi"
              cpu: "500m"
      volumes:
        - name: glpi-config
          persistentVolumeClaim:
            claimName: glpi-config
        - name: glpi-marketplace
          persistentVolumeClaim:
            claimName: glpi-marketplace
        - name: glpi-plugins
          persistentVolumeClaim:
            claimName: glpi-plugins
        - name: glpi-files
          persistentVolumeClaim:
            claimName: glpi-files
        - name: crontab-volume
          configMap:
            name: glpi-crontab

```