### PR TITLE
Update Dockerfile and add php-bcmath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt update \
 apache2 \
 php8.3 \
 php8.3-mysql \
+php8.3-bcmath \
 php8.3-ldap \
 php8.3-xmlrpc \
 php8.3-imap \


### PR DESCRIPTION
Add php-bcmath extension to support GLPI >= 11.0.0

When trying out the 11.0.0-alpha the installer requires the bcmath PHP extension.